### PR TITLE
Species Dropdown Selection bug

### DIFF
--- a/bloombox-strain.html
+++ b/bloombox-strain.html
@@ -198,9 +198,9 @@
           <paper-dropdown-menu id="speciesField" label="Species" tabindex="3" class="form-item" noink auto-validate required name="species">
             <paper-listbox class="dropdown-content" selected="[[species]]" attr-for-selected="key">
               <paper-item key="Indica">Indica</paper-item>
-              <paper-item key="Hybrid > Indica Dominant">Hybrid (Indica)</paper-item>
-              <paper-item key="Hybrid">Hybrid (No Dominance)</paper-item>
-              <paper-item key="Hybrid > Sativa Dominant">Hybrid (Sativa)</paper-item>
+              <paper-item key="Hybrid (Indica Dominant)">Hybrid (Indica Dominant)</paper-item>
+              <paper-item key="Hybrid (No Dominance)">Hybrid (No Dominance)</paper-item>
+              <paper-item key="Hybrid (Sativa Dominant)">Hybrid (Sativa Dominant)</paper-item>
               <paper-item key="Sativa">Sativa</paper-item>
               <paper-item key="Unspecified" class="unspecified-item-value">Unspecified</paper-item>
             </paper-listbox>


### PR DESCRIPTION
This addresses an issue where any variant of "Hybrid" is selected  when creating or editing a flower. When you save the product and then return to edit it, the species field doesn't stay populated.

I changed the "paper-item key" to match the values that it should be looking for. Please check it out and advise on whether or not this is an acceptable fix and that it won't break a bunch of stuff.